### PR TITLE
Alias C type to allow for external WebRtcVadInst type reference

### DIFF
--- a/vad.go
+++ b/vad.go
@@ -12,18 +12,20 @@ import (
 	"unsafe"
 )
 
+type VadInst *C.struct_WebRtcVadInst
+
 // Create Creates an instance to the VAD structure.
-func Create() *C.struct_WebRtcVadInst {
-	return C.WebRtcVad_Create()
+func Create() VadInst {
+	return VadInst(C.WebRtcVad_Create())
 }
 
 // Free Frees the dynamic memory of a specified VAD instance.
-func Free(vadInst *C.struct_WebRtcVadInst) {
+func Free(vadInst VadInst) {
 	C.WebRtcVad_Free(vadInst)
 }
 
 // Init Initializes a VAD instance.
-func Init(vadInst *C.struct_WebRtcVadInst) (err error) {
+func Init(vadInst VadInst) (err error) {
 	result := C.WebRtcVad_Init(vadInst)
 	if result == -1 {
 		err = errors.New("null pointer or Default mode could not be set")
@@ -32,7 +34,7 @@ func Init(vadInst *C.struct_WebRtcVadInst) (err error) {
 }
 
 // SetMode Sets the VAD operating mode.
-func SetMode(vadInst *C.struct_WebRtcVadInst, mode int) (err error) {
+func SetMode(vadInst VadInst, mode int) (err error) {
 	result := C.WebRtcVad_set_mode(vadInst, C.int(mode))
 	if result == -1 {
 		err = errors.New("mode could not be set or the VAD instance has not been initialized")
@@ -41,7 +43,7 @@ func SetMode(vadInst *C.struct_WebRtcVadInst, mode int) (err error) {
 }
 
 // Process Sets the VAD operating mode.
-func Process(vadInst *C.struct_WebRtcVadInst, fs int, audioFrame []byte, frameLength int) (active bool, err error) {
+func Process(vadInst VadInst, fs int, audioFrame []byte, frameLength int) (active bool, err error) {
 	result := C.WebRtcVad_Process(vadInst, C.int(fs), (*C.short)(unsafe.Pointer(&audioFrame[0])), C.size_t(frameLength))
 	if result == 1 {
 		active = true


### PR DESCRIPTION
To use VAD instance in some context, for example: a struct field, `sync.Pool`, etc. it's necessary to reference the type explicitly.
Related details: https://github.com/golang/go/issues/13467

I did not test this with Go 1.14 (as per `go.mod`) but it works with 1.21.