### PR TITLE
Specify c compiler flags not to warn

### DIFF
--- a/vad.go
+++ b/vad.go
@@ -3,6 +3,7 @@ package webrtcvad
 // #cgo linux CPPFLAGS: -DWEBRTC_POSIX
 // #cgo darwin CPPFLAGS: -DWEBRTC_POSIX
 // #cgo windows CPPFLAGS: -DWEBRTC_WIN
+// #cgo CPPFLAGS: -Wno-deprecated-builtins
 // #cgo CPPFLAGS: -I${SRCDIR}/webrtc_lkgr
 // #cgo CXXFLAGS: -std=c++11
 // #include "webrtc_lkgr/common_audio/vad/webrtc_vad.c"


### PR DESCRIPTION
Thank you for your wonderful library.

On macOS cgo uses Apple's cc(clang) by default.
Therefore, when I use the library on macOS, I get a warning saying “__has_trivial_destructor is deprecated”.

```
# github.com/baabaaox/go-webrtcvad
In file included from vad.cc:1:
In file included from ./webrtc_lkgr/rtc_base/checks.cc:36:
In file included from ../../../../go/pkg/mod/github.com/baabaaox/go-webrtcvad@v1.0.2/webrtc_lkgr/rtc_base/checks.h:57:
../../../../go/pkg/mod/github.com/baabaaox/go-webrtcvad@v1.0.2/webrtc_lkgr/absl/meta/type_traits.h:299:36: warning: builtin __has_trivial_destructor is deprecated; use __is_trivially_destructible instead [-Wdeprecated-builtins]
../../../../go/pkg/mod/github.com/baabaaox/go-webrtcvad@v1.0.2/webrtc_lkgr/absl/meta/type_traits.h:348:36: warning: builtin __has_trivial_constructor is deprecated; use __is_trivially_constructible instead [-Wdeprecated-builtins]
../../../../go/pkg/mod/github.com/baabaaox/go-webrtcvad@v1.0.2/webrtc_lkgr/absl/meta/type_traits.h:492:17: warning: builtin __has_trivial_assign is deprecated; use __is_trivially_assignable instead [-Wdeprecated-builtins]
../../../../go/pkg/mod/github.com/baabaaox/go-webrtcvad@v1.0.2/webrtc_lkgr/absl/meta/type_traits.h:536:8: warning: builtin __has_trivial_copy is deprecated; use __is_trivially_copyable instead [-Wdeprecated-builtins]
../../../../go/pkg/mod/github.com/baabaaox/go-webrtcvad@v1.0.2/webrtc_lkgr/absl/meta/type_traits.h:537:8: warning: builtin __has_trivial_assign is deprecated; use __is_trivially_assignable instead [-Wdeprecated-builtins]
```


This phenomenon seems to occur not only on macOS, but also on some Linux C compilers.

In essence, I should probably stop using `__has_trivial_destructor` and change it to `__is_trivially_destructible`, but for now, ignoring the warning does not seem to cause any problems, so I added a flag to suppress the warning I added a flag to suppress warnings since it does not seem to be a problem to ignore them for now.